### PR TITLE
Make sure config is in scope for kue init

### DIFF
--- a/lib/queue/kue.js
+++ b/lib/queue/kue.js
@@ -1,6 +1,7 @@
 var Q = require("q");
 var kue = require('kue');
 var url = require('url');
+var config = require("../config");
 var logger = require("../utils/logger")("queue");
 
 var jobs;


### PR DESCRIPTION
I was playing around creating [a Docker image](https://github.com/md5/docker-reportr-dashboard) for Reportr and hit this error:

```
ReferenceError: config is not defined
    at Object.init (/usr/src/app/lib/queue/kue.js:11:30)
    at /usr/src/app/lib/index.js:22:22
    at _fulfilled (/usr/src/app/node_modules/q/q.js:787:54)
    at self.promiseDispatch.done (/usr/src/app/node_modules/q/q.js:816:30)
    at Promise.promise.promiseDispatch (/usr/src/app/node_modules/q/q.js:749:13)
    at /usr/src/app/node_modules/q/q.js:557:44
    at flush (/usr/src/app/node_modules/q/q.js:108:17)
    at process._tickDomainCallback (node.js:463:13)
```

This patch made things work.
